### PR TITLE
User updates

### DIFF
--- a/haus-keeper/src/main/java/org/commonhaus/automation/hk/UserLoginVerifier.java
+++ b/haus-keeper/src/main/java/org/commonhaus/automation/hk/UserLoginVerifier.java
@@ -7,7 +7,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.Duration;
-import java.util.List;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -176,6 +176,6 @@ public class UserLoginVerifier extends ScheduledService {
         return ME;
     }
 
-    public record LoginChangeEvent(String oldLogin, Optional<String> newLogin, List<String> projects) {
+    public record LoginChangeEvent(String oldLogin, Optional<String> newLogin, Collection<String> projects) {
     }
 }

--- a/haus-keeper/src/main/java/org/commonhaus/automation/hk/api/KnownUserInterceptor.java
+++ b/haus-keeper/src/main/java/org/commonhaus/automation/hk/api/KnownUserInterceptor.java
@@ -43,7 +43,8 @@ public class KnownUserInterceptor implements Serializable {
             }
             return Response.status(Response.Status.FORBIDDEN).build();
         } catch (Exception e) {
-            appCtx.logAndSendEmail("😎-known", "[%s] Exception checking for known user", e);
+            appCtx.logAndSendEmail("😎-known", "Exception checking for known user",
+                    "Exception checking for user %s".formatted(session.login()), e);
             if (e instanceof WebApplicationException) {
                 return ((WebApplicationException) e).getResponse();
             }

--- a/haus-keeper/src/main/java/org/commonhaus/automation/hk/config/ProjectAliasMapping.java
+++ b/haus-keeper/src/main/java/org/commonhaus/automation/hk/config/ProjectAliasMapping.java
@@ -1,6 +1,6 @@
 package org.commonhaus.automation.hk.config;
 
-import java.util.List;
+import java.util.Set;
 
 import org.commonhaus.automation.config.EmailNotification;
 
@@ -12,7 +12,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 @RegisterForReflection
 public record ProjectAliasMapping(
         String domain,
-        List<UserAliasList> userMapping,
+        Set<UserAliasList> userMapping,
         EmailNotification emailNotifications) {
 
     public static final String CONFIG_FILE = "project-mail-aliases.yml";
@@ -22,7 +22,7 @@ public record ProjectAliasMapping(
      */
     public record UserAliasList(
             String login,
-            List<String> aliases) {
+            Set<String> aliases) {
 
         public boolean isValid(String projectDomain) {
             return login != null && !login.isEmpty()

--- a/haus-keeper/src/main/java/org/commonhaus/automation/hk/data/CommonhausUserData.java
+++ b/haus-keeper/src/main/java/org/commonhaus/automation/hk/data/CommonhausUserData.java
@@ -3,7 +3,6 @@ package org.commonhaus.automation.hk.data;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -70,7 +69,7 @@ public class CommonhausUserData {
             return altAlias;
         }
 
-        public void addAliases(List<String> validAliases) {
+        public void addAliases(Collection<String> validAliases) {
             altAlias().addAll(validAliases);
         }
 

--- a/haus-keeper/src/main/java/org/commonhaus/automation/hk/data/CommonhausUserData.java
+++ b/haus-keeper/src/main/java/org/commonhaus/automation/hk/data/CommonhausUserData.java
@@ -1,16 +1,17 @@
 package org.commonhaus.automation.hk.data;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import jakarta.annotation.Nonnull;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 public class CommonhausUserData {
     @Nonnull
@@ -21,9 +22,10 @@ public class CommonhausUserData {
 
     Services services = new Services();
 
-    List<String> projects = new ArrayList<>();
+    @JsonDeserialize(as = TreeSet.class)
+    Set<String> projects = new TreeSet<>();
 
-    public List<String> projects() {
+    public Collection<String> projects() {
         return projects;
     }
 
@@ -152,10 +154,6 @@ public class CommonhausUserData {
         this.status = other.status;
         this.goodUntil.merge(other.goodUntil);
         this.services.merge(other.services);
-        if (other.projects != null) {
-            other.projects().stream()
-                    .filter(project -> !this.projects.contains(project))
-                    .forEach(this.projects::add);
-        }
+        this.projects().addAll(other.projects());
     }
 }

--- a/haus-keeper/src/main/java/org/commonhaus/automation/hk/github/CommonhausDatastore.java
+++ b/haus-keeper/src/main/java/org/commonhaus/automation/hk/github/CommonhausDatastore.java
@@ -18,14 +18,12 @@ import org.commonhaus.automation.hk.data.CommonhausUser;
 import org.commonhaus.automation.hk.github.DatastoreEvent.QueryEvent;
 import org.commonhaus.automation.hk.github.DatastoreEvent.UpdateEvent;
 import org.commonhaus.automation.hk.member.MemberInfo;
-import org.commonhaus.automation.mail.LogMailer;
 import org.commonhaus.automation.queue.PeriodicUpdateQueue;
 import org.kohsuke.github.GHContent;
 import org.kohsuke.github.GHContentBuilder;
 import org.kohsuke.github.GHContentUpdateResponse;
 import org.kohsuke.github.GHRepository;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import io.quarkus.logging.Log;
@@ -319,20 +317,9 @@ public class CommonhausDatastore {
         if (user == null) {
             return null;
         }
-        // create a disconnected copy of the essential data.
-        try {
-            String json = ContextService.yamlMapper.writeValueAsString(user);
-            CommonhausUser copy = ContextService.yamlMapper.readValue(json, CommonhausUser.class);
-            copy.sha(user.sha());
-            Log.debugf("Deep copy of %s", user, copy);
-            return copy;
-        } catch (JsonProcessingException e) {
-            LogMailer.instance().logAndSendEmail(
-                    "CommonhausDatastore.deepCopy",
-                    "Unable to copy Commonbaus user",
-                    e);
-        }
-        return user;
+        CommonhausUser copy = new CommonhausUser.Builder().copy(user).build();
+        copy.sha(user.sha());
+        return copy;
     }
 
     void initializeJournal() {

--- a/haus-keeper/src/main/java/org/commonhaus/automation/hk/github/DatastoreEvent.java
+++ b/haus-keeper/src/main/java/org/commonhaus/automation/hk/github/DatastoreEvent.java
@@ -69,9 +69,10 @@ public interface DatastoreEvent {
         }
 
         public void applyChanges(AppContextService ctx, CommonhausUser user) {
+            CommonhausUser original = CommonhausDatastore.deepCopy(user);
             updateUser.accept(ctx, user);
-            // Add to history if requested
-            if (history) {
+            // Add to history if requested and object was changed
+            if (history && !original.equals(user)) {
                 user.addHistory(message);
             }
         }

--- a/haus-keeper/src/test/java/org/commonhaus/automation/hk/api/MemberDataTest.java
+++ b/haus-keeper/src/test/java/org/commonhaus/automation/hk/api/MemberDataTest.java
@@ -217,7 +217,6 @@ public class MemberDataTest extends HausKeeperTestBase {
             @UserInfo(key = "avatar_url", value = "https://avatars.githubusercontent.com/u/156364140?v=4")
     })
     void testGetCommonhausUser() throws Exception {
-
         mockExistingCommonhausData(UserPath.WITH_ATTESTATION);
 
         GHUser botUser = sponsorMocks.github().getUser(botLogin);

--- a/haus-keeper/src/test/java/org/commonhaus/automation/hk/data/CommonhausUserTest.java
+++ b/haus-keeper/src/test/java/org/commonhaus/automation/hk/data/CommonhausUserTest.java
@@ -2,6 +2,8 @@ package org.commonhaus.automation.hk.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
 
 import org.commonhaus.automation.hk.github.HausKeeperTestBase;
@@ -52,5 +54,82 @@ public class CommonhausUserTest extends HausKeeperTestBase {
         assertThat(update).isTrue();
         user.updateMemberStatus(ctx, roles);
         assertThat(user.status()).isEqualTo(MemberStatus.COMMITTEE);
+    }
+
+    @Test
+    void testMergeCommonhausUser() {
+        // Create the first user with some history
+        CommonhausUser user1 = new CommonhausUser.Builder()
+                .withId(12345)
+                .withData(new CommonhausUserData())
+                .build();
+        user1.data.projects().add("user1-project");
+        user1.data.projects().add("other-project");
+        user1.history.addAll(List.of(
+                "2025-03-12T14:35:00Z Membership application accepted",
+                "2025-03-18T09:51:00Z Sign attestation (email|fe-2024-05-31)"));
+
+        // Create the second user with overlapping and new history
+        CommonhausUser user2 = new CommonhausUser.Builder()
+                .withId(12345)
+                .withData(new CommonhausUserData())
+                .build();
+        user2.data.projects().add("user2-project");
+        user2.data.projects().add("other-project");
+        user2.history.addAll(List.of(
+                "2025-03-18T09:51:00Z Sign attestation (email|fe-2024-05-31)", // Duplicate
+                "2025-03-18T09:54:00Z Sign attestation (coc|cf-2024-06-07)",
+                "2025-04-15T02:15:00Z Update user aliases for hibernate.org"));
+
+        // Merge user2 into user1
+        user1.merge(user2);
+
+        // Validate the merged history
+        assertThat(user1.history).containsExactly(
+                "2025-03-12T14:35:00Z Membership application accepted",
+                "2025-03-18T09:51:00Z Sign attestation (email|fe-2024-05-31)",
+                "2025-03-18T09:54:00Z Sign attestation (coc|cf-2024-06-07)",
+                "2025-04-15T02:15:00Z Update user aliases for hibernate.org");
+        assertThat(user1.projects()).containsExactly(
+                "other-project",
+                "user1-project",
+                "user2-project");
+    }
+
+    @Test
+    void testYamlSerializationDeserialization() throws Exception {
+        // Create a user with history
+        CommonhausUser user = new CommonhausUser.Builder()
+                .withId(12345)
+                .withData(new CommonhausUserData())
+                .build();
+        user.history.addAll(List.of(
+                "2025-03-12T14:35:00Z Membership application accepted",
+                "2025-03-18T09:51:00Z Sign attestation (email|fe-2024-05-31)"));
+        user.data.projects().add("test-project");
+        user.data.projects().add("other-project");
+
+        // Serialize to YAML
+        String yaml = ctx.yamlMapper().writeValueAsString(user);
+
+        // Deserialize back to object
+        CommonhausUser deserializedUser = ctx.yamlMapper().readValue(yaml, CommonhausUser.class);
+
+        // Validate the deserialized object
+        assertThat(deserializedUser.id).isEqualTo(user.id);
+        assertThat(deserializedUser.history).isEqualTo(user.history);
+        assertThat(deserializedUser.projects()).isEqualTo(user.projects());
+    }
+
+    @Test
+    void testGetCommonhausUserData() throws Exception {
+        Path userFile = Path.of(UserPath.WITH_ATTESTATION.filename());
+        CommonhausUser user = ctx.yamlMapper().readValue(userFile.toFile(), CommonhausUser.class);
+        assertThat(user).isNotNull();
+        assertThat(user.id).isEqualTo(156364140);
+        assertThat(user.login).isEqualTo("commonhaus-bot");
+        assertThat(user.data).isNotNull();
+        assertThat(user.data.goodUntil).isNotNull();
+        assertThat(user.data.goodUntil.dues).isEqualTo("2020-01-01");
     }
 }

--- a/haus-keeper/src/test/java/org/commonhaus/automation/hk/github/HausKeeperTestBase.java
+++ b/haus-keeper/src/test/java/org/commonhaus/automation/hk/github/HausKeeperTestBase.java
@@ -284,7 +284,7 @@ public class HausKeeperTestBase extends ContextHelper {
             this.filename = filename;
         }
 
-        String filename() {
+        public String filename() {
             return filename;
         }
     }

--- a/haus-manager/src/main/java/org/commonhaus/automation/hm/OrganizationManager.java
+++ b/haus-manager/src/main/java/org/commonhaus/automation/hm/OrganizationManager.java
@@ -195,8 +195,9 @@ public class OrganizationManager extends GroupCoordinator implements LatestOrgCo
         }
         OrganizationConfig orgCfg = qc.readYamlContent(content, OrganizationConfig.class);
         if (orgCfg == null || qc.hasErrors()) {
-            qc.logAndSendContextErrors("[%s] readOrgConfig: unable to parse %s in %s"
-                    .formatted(ME, OrganizationConfig.PATH, repo.getFullName()),
+            qc.logAndSendEmail("readOrgConfig: unable to parse configuraton",
+                    "Unable to parse %s in %s".formatted(OrganizationConfig.PATH, repo.getFullName()),
+                    qc.bundleExceptions(),
                     orgCfg.emailNotifications());
             return false;
         }


### PR DESCRIPTION
1) Simplify process for deep copies (reuse merge functions)
2) Add tests for user read/write/copy (sorted projects, sorted history, no duplicates)
3) Only add line to history if object was changed