### PR TITLE
Consider only direct collaborators for the sync feature

### DIFF
--- a/bot-github-core/src/main/java/org/commonhaus/automation/github/context/BaseQueryCache.java
+++ b/bot-github-core/src/main/java/org/commonhaus/automation/github/context/BaseQueryCache.java
@@ -5,6 +5,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
 import org.commonhaus.automation.QueryCache;
+import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 
 import com.cronutils.Function;
@@ -18,10 +19,20 @@ public enum BaseQueryCache {
     LABELS(b -> b.expireAfterWrite(1, TimeUnit.DAYS)),
     TEAM_MEMBERS(b -> b.expireAfterWrite(1, TimeUnit.DAYS)),
     COLLABORATORS(b -> b.expireAfterWrite(1, TimeUnit.DAYS)),
+    DIRECT_COLLABORATORS(b -> b.expireAfterWrite(1, TimeUnit.DAYS)),
+    OUTSIDE_COLLABORATORS(b -> b.expireAfterWrite(1, TimeUnit.DAYS)),
 
     BOT_LOGIN(b -> b.expireAfterWrite(6, TimeUnit.HOURS)),
 
     RECENT_BOT_CONTENT(b -> b.expireAfterWrite(6, TimeUnit.HOURS));
+
+    public static BaseQueryCache getCollaboratorsCache(GHRepository.CollaboratorAffiliation affiliation) {
+        return switch (affiliation) {
+            case DIRECT -> DIRECT_COLLABORATORS;
+            case ALL -> COLLABORATORS;
+            case OUTSIDE -> OUTSIDE_COLLABORATORS;
+        };
+    }
 
     private QueryCache cache = null;
 

--- a/bot-github-core/src/main/java/org/commonhaus/automation/github/context/DataRepository.java
+++ b/bot-github-core/src/main/java/org/commonhaus/automation/github/context/DataRepository.java
@@ -28,7 +28,7 @@ public class DataRepository extends DataCommonType {
     static final String QUERY_ADMINS = """
             query($owner: String!, $name: String!, $after: String) {
                 repository(owner: $owner, name: $name) {
-                    collaborators(first: 100, after: $after) {
+                    collaborators(affiliation: $affiliation, first: 100, after: $after) {
                         edges {
                             node {
                                 login
@@ -279,12 +279,14 @@ public class DataRepository extends DataCommonType {
         return count;
     }
 
-    public static Collaborators queryCollaborators(GitHubQueryContext qc, String repoFullName) {
+    public static Collaborators queryCollaborators(GitHubQueryContext qc, String repoFullName,
+            GHRepository.CollaboratorAffiliation affiliation) {
         Map<String, Object> variables = new HashMap<>();
         String org = toOrganizationName(repoFullName);
         String name = toRelativeName(org, repoFullName);
         variables.putIfAbsent("owner", org);
         variables.putIfAbsent("name", name);
+        variables.putIfAbsent("affiliation", affiliation.name());
 
         Set<Collaborator> members = new HashSet<>();
         DataPageInfo pageInfo = new DataPageInfo(null, false);

--- a/bot-github-core/src/test/java/org/commonhaus/automation/github/context/GitHubTeamServiceTest.java
+++ b/bot-github-core/src/test/java/org/commonhaus/automation/github/context/GitHubTeamServiceTest.java
@@ -446,7 +446,7 @@ public class GitHubTeamServiceTest extends ContextHelper {
                                         .add("hasNextPage", false))))
                 .build();
 
-        mockResponse("collaborators(first: 100, after: $after)", jsonObject);
+        mockResponse("collaborators(affiliation: $affiliation, first: 100, after: $after)", jsonObject);
     }
 
     final static class MockContextService {


### PR DESCRIPTION
Because considering indirect collaborators leads to attempts to remove collaborators that are only there because of a team, which can never work.